### PR TITLE
Adding jbusecke as admin user

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -42,6 +42,7 @@ basehub:
           # the listed teams. These people should have admin access though.
           admin_users:
             - rabernat
+            - jbusecke
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:


### PR DESCRIPTION
Hi, I am the new Manager for Data and Computing at LEAP. 

It would be great if I could have access to the [grafana dashboard](https://grafana.leap.2i2c.cloud/login) by today, so I can show some useage statistics at a meeting tomorrow. 

Thanks